### PR TITLE
Add employee loan persistence and payroll deduction support

### DIFF
--- a/app/Http/Controllers/EmployeeLoanPaymentController.php
+++ b/app/Http/Controllers/EmployeeLoanPaymentController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Helper\Reply;
+use App\Models\EmployeeLoanPayment;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+
+class EmployeeLoanPaymentController extends AccountBaseController
+{
+    public function store(Request $request)
+    {
+        $this->addPermission = user()->permission('add_payroll');
+        abort_403(!in_array($this->addPermission, ['all', 'added']));
+
+        $data = $request->validate([
+            'employee_loan_payment_id' => 'required|exists:employee_loan_payments,id',
+            'amount' => 'required|numeric|min:0.01',
+            'paid_on' => 'nullable|date',
+            'notes' => 'nullable|string',
+        ]);
+
+        $loanPayment = EmployeeLoanPayment::with('loan')->findOrFail($data['employee_loan_payment_id']);
+
+        $amount = round($data['amount'], 2);
+        $loanPayment->amount_paid = min($loanPayment->amount_due, round($loanPayment->amount_paid + $amount, 2));
+        $loanPayment->salary_slip_id = null;
+
+        if (!empty($data['notes'])) {
+            $loanPayment->notes = $data['notes'];
+        }
+
+        if ($loanPayment->amount_paid >= $loanPayment->amount_due) {
+            $paidOn = $data['paid_on']
+                ? Carbon::parse($data['paid_on'])->setTimezone($this->company->timezone)
+                : now()->setTimezone($this->company->timezone);
+
+            $loanPayment->markPaid($paidOn);
+        } else {
+            $loanPayment->status = EmployeeLoanPayment::STATUS_PARTIAL;
+
+            if (!empty($data['paid_on'])) {
+                $loanPayment->paid_on = Carbon::parse($data['paid_on'])->setTimezone($this->company->timezone);
+            }
+        }
+
+        $loanPayment->save();
+
+        return Reply::success(__('messages.recordSaved'));
+    }
+}

--- a/app/Models/EmployeeLoan.php
+++ b/app/Models/EmployeeLoan.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\User;
+
+
+class EmployeeLoan extends BaseModel
+{
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'start_date' => 'date',
+        'end_date' => 'date',
+        'principal_amount' => 'float',
+        'installment_amount' => 'float',
+    ];
+
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_CLOSED = 'closed';
+
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function payments(): HasMany
+    {
+        return $this->hasMany(EmployeeLoanPayment::class);
+    }
+}

--- a/app/Models/EmployeeLoanPayment.php
+++ b/app/Models/EmployeeLoanPayment.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EmployeeLoanPayment extends BaseModel
+{
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'due_date' => 'date',
+        'paid_on' => 'date',
+        'amount_due' => 'float',
+        'amount_paid' => 'float',
+    ];
+
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_PARTIAL = 'partial';
+    public const STATUS_PAID = 'paid';
+
+    protected $appends = ['outstanding_amount'];
+
+    public function loan(): BelongsTo
+    {
+        return $this->belongsTo(EmployeeLoan::class);
+    }
+
+    public function salarySlip(): BelongsTo
+    {
+        return $this->belongsTo(\Modules\Payroll\Entities\SalarySlip::class, 'salary_slip_id');
+    }
+
+    public function getOutstandingAmountAttribute(): float
+    {
+        $outstanding = ($this->amount_due ?? 0) - ($this->amount_paid ?? 0);
+
+        return $outstanding > 0 ? (float) $outstanding : 0.0;
+    }
+
+    public function markPaid(?CarbonInterface $paidOn = null, ?string $status = null): void
+    {
+        $this->status = $status ?? self::STATUS_PAID;
+
+        if ($paidOn) {
+            $this->paid_on = $paidOn;
+        } elseif (! $this->paid_on) {
+            $this->paid_on = now();
+        }
+    }
+}

--- a/app/Services/Payroll/LoanRepaymentAllocator.php
+++ b/app/Services/Payroll/LoanRepaymentAllocator.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Services\Payroll;
+
+use App\Models\EmployeeLoan;
+use App\Models\EmployeeLoanPayment;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Modules\Payroll\Entities\SalarySlip;
+
+class LoanRepaymentAllocator
+{
+    public function getDeductionsForPeriod(User $user, Carbon $periodStart, Carbon $periodEnd): array
+    {
+        $payments = EmployeeLoanPayment::with('loan')
+            ->whereHas('loan', function ($query) use ($user) {
+                $query->where('user_id', $user->id)
+                    ->where('status', EmployeeLoan::STATUS_ACTIVE);
+            })
+            ->whereNull('salary_slip_id')
+            ->whereDate('due_date', '>=', $periodStart->toDateString())
+            ->whereDate('due_date', '<=', $periodEnd->toDateString())
+            ->orderBy('due_date')
+            ->get();
+
+        $entries = [];
+        $total = 0.0;
+        $processedPayments = collect();
+
+        foreach ($payments as $payment) {
+            if ($payment->outstanding_amount <= 0) {
+                if ($payment->status !== EmployeeLoanPayment::STATUS_PAID) {
+                    $payment->markPaid();
+                    $payment->save();
+                }
+
+                continue;
+            }
+
+            $label = sprintf(
+                'Loan - %s (%s)',
+                $payment->loan->title,
+                $payment->due_date ? $payment->due_date->format('M d, Y') : ''
+            );
+
+            $entries[] = [
+                'label' => $label,
+                'amount' => $payment->outstanding_amount,
+            ];
+
+            $total += $payment->outstanding_amount;
+            $processedPayments->push($payment);
+        }
+
+        return [
+            'entries' => $entries,
+            'total' => $total,
+            'payments' => $processedPayments,
+        ];
+    }
+
+    public function markProcessed(Collection $payments, SalarySlip $salarySlip): void
+    {
+        $payments->each(function (EmployeeLoanPayment $payment) use ($salarySlip) {
+            $outstanding = $payment->outstanding_amount;
+
+            if ($outstanding <= 0) {
+                return;
+            }
+
+            $payment->amount_paid = round($payment->amount_paid + $outstanding, 2);
+            $payment->salary_slip_id = $salarySlip->id;
+            $payment->markPaid($salarySlip->salary_to ?? now());
+            $payment->save();
+        });
+    }
+}

--- a/database/migrations/2024_04_27_000001_create_employee_loans_table.php
+++ b/database/migrations/2024_04_27_000001_create_employee_loans_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('employee_loans', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('title');
+            $table->decimal('principal_amount', 15, 2);
+            $table->decimal('installment_amount', 15, 2);
+            $table->string('installment_frequency');
+            $table->date('start_date');
+            $table->date('end_date')->nullable();
+            $table->string('status')->default('active');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('employee_loans');
+    }
+};

--- a/database/migrations/2024_04_27_000002_create_employee_loan_payments_table.php
+++ b/database/migrations/2024_04_27_000002_create_employee_loan_payments_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('employee_loan_payments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('employee_loan_id')->constrained()->onDelete('cascade');
+            $table->date('due_date');
+            $table->decimal('amount_due', 15, 2);
+            $table->decimal('amount_paid', 15, 2)->default(0);
+            $table->date('paid_on')->nullable();
+            $table->string('status')->default('pending');
+            $table->foreignId('salary_slip_id')->nullable()->constrained('salary_slips')->nullOnDelete();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('employee_loan_payments');
+    }
+};


### PR DESCRIPTION
## Summary
- add employee loan and employee loan payment tables and models to persist loan schedules
- integrate a loan repayment allocator into payroll slip generation so due installments become deductions
- handle manual loan repayments to update scheduled installments and avoid duplicate payroll deductions

## Testing
- php artisan test *(fails: vendor/autoload.php is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e14bbd142c83328a27246e45c5e711