### PR TITLE
Fix office loan deductions on payslip

### DIFF
--- a/application/modules/hrm/controllers/Payroll.php
+++ b/application/modules/hrm/controllers/Payroll.php
@@ -1600,17 +1600,19 @@ class Payroll extends MX_Controller {
 		$component_breakdown = $this->Payroll_model->calculate_component_breakdown($salary_info);
 		$component_add_total = isset($component_breakdown['earning_total']) ? (float) $component_breakdown['earning_total'] : 0.0;
 		$component_ded_total = isset($component_breakdown['deduction_total']) ? (float) $component_breakdown['deduction_total'] : 0.0;
-		$loan_total = floatval($salary_info->loan_deduct);
-		$salary_advance_total = floatval($salary_info->salary_advance);
+                $loan_total = floatval($salary_info->loan_deduct);
+                $office_loan_total = floatval($salary_info->office_loan_deduct);
+                $salary_advance_total = floatval($salary_info->salary_advance);
 
 		$data['component_breakdown'] = $component_breakdown;
 		$data['component_add_total'] = round($component_add_total, 2);
 		$data['component_ded_total'] = round($component_ded_total, 2);
-		$data['loan_total'] = round($loan_total, 2);
-		$data['salary_advance_total'] = round($salary_advance_total, 2);
+                $data['loan_total'] = round($loan_total, 2);
+                $data['office_loan_total'] = round($office_loan_total, 2);
+                $data['salary_advance_total'] = round($salary_advance_total, 2);
 
-		$total_deductions = $component_ded_total + $loan_total + $salary_advance_total;
-		$data['total_deductions'] = round($total_deductions, 2);
+                $total_deductions = $component_ded_total + $loan_total + $office_loan_total + $salary_advance_total;
+                $data['total_deductions'] = round($total_deductions, 2);
 
 		$post_gross_total = isset($salary_info->gross_salary) ? ((float) $salary_info->gross_salary + $component_add_total) : $component_add_total;
 		$data['post_gross_total'] = round($post_gross_total, 2);

--- a/application/modules/hrm/views/employee_salary/pay_slip.php
+++ b/application/modules/hrm/views/employee_salary/pay_slip.php
@@ -167,6 +167,7 @@
                     $component_ded_total_display = round($component_ded_total, 2);
                     $loan_total_display = isset($loan_total) ? (float) $loan_total : (isset($salary_info->loan_deduct) ? (float) $salary_info->loan_deduct : 0.0);
                     $salary_advance_display = isset($salary_advance_total) ? (float) $salary_advance_total : (isset($salary_info->salary_advance) ? (float) $salary_info->salary_advance : 0.0);
+                    $office_loan_display = isset($office_loan_total) ? (float) $office_loan_total : (isset($salary_info->office_loan_deduct) ? (float) $salary_info->office_loan_deduct : 0.0);
                     $net_salary_display = isset($net_salary_calculated) ? (float) $net_salary_calculated : (isset($salary_info->net_salary) ? (float) $salary_info->net_salary : 0.0);
                     $post_gross_total_display = isset($post_gross_total) ? (float) $post_gross_total : ((isset($salary_info->gross_salary) ? (float) $salary_info->gross_salary : 0.0) + $component_add_total);
                     $social_security_combined_display = isset($social_security_combined_total) ? (float) $social_security_combined_total : (floatval($salary_info->employer_contribution) + floatval($salary_info->soc_sec_npf_tax));
@@ -272,14 +273,13 @@
                                 </tr>
                                 
                                 <?php 
-                                $office_loan_deduct = isset($salary_info->office_loan_deduct) ? (float) $salary_info->office_loan_deduct : 0.0;
-                                if ($office_loan_deduct > 0) { ?>
+                                if ($office_loan_display > 0) { ?>
                                 <tr style="text-align: left !important;">
                                     <th style="text-align: left !important;">Office Loan Deduction</th>
                                     <td></td>
                                     <td></td>
                                     <td></td>
-                                    <td style="text-align: left !important;"><?php echo $curncy_symbol.' '.number_format($office_loan_deduct,2);?></td>
+                                    <td style="text-align: left !important;"><?php echo $curncy_symbol.' '.number_format($office_loan_display,2);?></td>
                                 </tr>
                                 <?php } ?>
                                 <tr style="text-align: left;">

--- a/application/modules/hrm/views/employee_salary/pay_slip_pdf.php
+++ b/application/modules/hrm/views/employee_salary/pay_slip_pdf.php
@@ -147,6 +147,7 @@
                     $component_ded_total_display = round($component_ded_total, 2);
                     $loan_total_display = isset($loan_total) ? (float) $loan_total : (isset($salary_info->loan_deduct) ? (float) $salary_info->loan_deduct : 0.0);
                     $salary_advance_display = isset($salary_advance_total) ? (float) $salary_advance_total : (isset($salary_info->salary_advance) ? (float) $salary_info->salary_advance : 0.0);
+                    $office_loan_display = isset($office_loan_total) ? (float) $office_loan_total : (isset($salary_info->office_loan_deduct) ? (float) $salary_info->office_loan_deduct : 0.0);
                     $net_salary_display = isset($net_salary_calculated) ? (float) $net_salary_calculated : (isset($salary_info->net_salary) ? (float) $salary_info->net_salary : 0.0);
                     $post_gross_total_display = isset($post_gross_total) ? (float) $post_gross_total : ((isset($salary_info->gross_salary) ? (float) $salary_info->gross_salary : 0.0) + $component_add_total);
                     $social_security_combined_display = isset($social_security_combined_total) ? (float) $social_security_combined_total : (floatval($salary_info->employer_contribution) + floatval($salary_info->soc_sec_npf_tax));
@@ -247,6 +248,15 @@
                                     <td></td>
                                     <td style="text-align: left !important;"><?php echo $curncy_symbol.' '.number_format($loan_total_display,2);?></td>
                                 </tr>
+                                <?php if ($office_loan_display > 0) { ?>
+                                <tr style="text-align: left !important;">
+                                    <th style="text-align: left !important;">Office Loan Deduction</th>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td style="text-align: left !important;"><?php echo $curncy_symbol.' '.number_format($office_loan_display,2);?></td>
+                                </tr>
+                                <?php } ?>
                                 <tr style="text-align: left !important;">
                                     <th style="text-align: left !important;">Salary Advance</th>
                                     <td></td>


### PR DESCRIPTION
## Summary
- include office loan amounts when computing payslip totals and net salary
- surface the office loan deduction value in both HTML and PDF payslip views

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e15c5c6acc83328a5912c122d06435